### PR TITLE
Add a "Guides" link to the home page header

### DIFF
--- a/index_cologne.py
+++ b/index_cologne.py
@@ -137,6 +137,8 @@ def purpos1ediv():
 
    <p>
      <a href='/scans/csldev/csldoc/build/index.html' target="_csldoc"><b>Documentation</b></a>
+   &nbsp; &nbsp;
+     <a href='https://sanskrit-lexicon.github.io/csl-guides/' target="_cslguides"><b>Guides</b></a>
    
 <!--
    &nbsp; &nbsp;


### PR DESCRIPTION
Adds a **Guides** link in the home-page header, next to **Documentation**, pointing to the Docusaurus guides at https://sanskrit-lexicon.github.io/csl-guides/.

The guides cover using the dictionaries (B/L/A/M displays, transliteration, downloads, scans), the auto-generated dictionary catalog, the tools, the correction/change-file workflow + issue taxonomy, and a developer/API reference — complementing the per-dictionary front-matter in csl-doc that the existing **Documentation** link targets.

Minimal change: one `<a>` (two lines) added after the Documentation link in `index_cologne.py`. Opening for maintainer review rather than merging, since this regenerates the live home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)